### PR TITLE
Exhaustivité de la fonction check_topo_on

### DIFF
--- a/tp1/graph_test.ml
+++ b/tp1/graph_test.ml
@@ -20,9 +20,13 @@ let graph_of_graph' a =
 
 let check_topo_on g =
   let l = topological (graph_of_graph' g) in
-  let inverse_l = Array.map (fun _ -> 0) g in
-  List.iteri (fun i node -> inverse_l.(node) <- i) l;
-  Array.for_all Fun.id (Array.mapi (fun i lst -> List.for_all (fun dst -> inverse_l.(i) < inverse_l.(dst)) lst) g)
+  let visited = Array.make (Array.length g) false in
+  let res = ref true in
+  List.iter (fun node ->
+    visited.(node) <- true;
+    List.iter (fun v -> if visited.(v) then res := false) g.(node)
+  ) l;
+  !res
 
 
 let test i (g, b) =


### PR DESCRIPTION
La précédente fonction reconnaissait `[5; 1; 0; 3; 2; 3; 4; 4; 6; 7; 6; 3; 8; 9; 8]` comme un tri topologique du graphe `g4`, alors que certains sommets sont répétés. Celle-ci la refuse.